### PR TITLE
[SCRT-26] added more info on the query permit modal & UI changes

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -63,7 +63,7 @@ export default function Header() {
       <div className="flex items-center min-h-full">
         <Link passHref={true} href="/learn">
           <p
-            className={`mr-5 text-xs sm:text-sm md:text-base text-center cursor-pointer hover:text-purple ${
+            className={`mr-5 text-xs sm:text-sm md:text-base text-center cursor-pointer hover:text-gray-400 ${
               showWallet ? 'disappear' : 'reappear'
             }`}
           >
@@ -73,7 +73,7 @@ export default function Header() {
         {secretAddress && (
           <Link passHref={true} href={'/start'}>
             <p
-              className={`mr-5 text-xs sm:text-sm md:text-base text-center cursor-pointer hover:text-purple ${
+              className={`mr-5 text-xs sm:text-sm md:text-base text-center cursor-pointer hover:text-gray-400 ${
                 showWallet ? 'disappear' : 'reappear'
               }`}
             >

--- a/src/pages/applicant/permit.tsx
+++ b/src/pages/applicant/permit.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { DownloadOutlined } from '@ant-design/icons';
-import { Modal } from 'antd';
+import { DownloadOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import { Modal, Tooltip } from 'antd';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { isEmpty, replace } from 'ramda';
@@ -75,7 +75,7 @@ const PermissionPage = () => {
   const inputDataInput = (onChange?: (e?: any) => void) => (
     <input
       onChange={onChange}
-      className=" z-50 focus-visible:outline-blue-600 focus-visible:outline-none  font-mono text-blue-600 bg-input-bg w-full py-3 px-3 rounded-md mb-4"
+      className=" z-50 focus-visible:outline-blue-600 focus-visible:outline-none font-mono text-blue-600 bg-input-bg w-full py-3 px-3 rounded-md mb-4 uppercase"
       type={'text'}
     />
   );
@@ -96,12 +96,18 @@ const PermissionPage = () => {
             <h3 className="text-lg mr-2 uppercase font-semibold ">
               Query Permit{' '}
             </h3>
-            <div className="bg-gray-500 w-4 h-4 rounded-full p-2 flex justify-center items-center cursor-pointer text-black">
-              i
-            </div>
+            <Tooltip
+              title="You can only view this key once. Make sure to save it and keep it safe."
+              placement="bottom"
+            >
+              <InfoCircleOutlined className="cursor-pointer hover:text-gray-500" />
+            </Tooltip>
           </div>
           <p className="mb-3 font-semibold">
-            Permit Name: <span className="font-thin">{inputData}</span>
+            Permit Name:{' '}
+            <span className="font-thin">
+              {inputData || permissionSig?.name}
+            </span>
           </p>
           <p className="mb-3 font-semibold">
             Public Key:{' '}
@@ -127,7 +133,7 @@ const PermissionPage = () => {
               <Button
                 text="Query Score"
                 style={BUTTON_STYLES.LINK}
-                classes={{ button: 'hover:text-blue' }}
+                classes={{ button: 'hover:text-gray-400' }}
                 onClick={() => {
                   router.push('/applicant/query');
                 }}
@@ -136,7 +142,7 @@ const PermissionPage = () => {
           </div>
           <div
             role={'presentation'}
-            className="mt-10 text-xs flex items-center  text-blue cursor-pointer"
+            className="mt-10 text-xs flex items-center text-blue cursor-pointer"
             onClick={() => {
               const element = document.createElement('a');
               const file = new Blob(
@@ -158,10 +164,12 @@ const PermissionPage = () => {
               document.body.removeChild(element);
             }}
           >
-            <span className="mr-1 text-base">
-              <DownloadOutlined />
-            </span>
-            <p className="mt-2">download permit</p>
+            <div className="hover:text-gray-500 flex">
+              <span className="mr-1 text-base">
+                <DownloadOutlined />
+              </span>
+              <p className="mt-2">Download permit</p>
+            </div>
           </div>
         </div>
       </div>
@@ -172,8 +180,21 @@ const PermissionPage = () => {
     <div className="px-10 sm:px-14 z-50 mt-20 mb-20 sm:mt-10">
       <div className="w-full text-center">
         <div className="z-50 opacity-100 px-0 sm:p-10 flex flex-col">
-          <h2 className="z-50 font-semibold text-2xl sm:text-3xl md:text-3xl lg:text-4xl p-0">
+          <h2 className="z-50 font-semibold text-2xl sm:text-3xl md:text-3xl lg:text-4xl p-0 flex items-center justify-center">
             {isCreate ? 'Create a query permit' : 'Revoke a query permit'}
+            <Tooltip
+              title={`${
+                isCreate
+                  ? 'Gas fees are not charged when creating a query permit and these permits can be shared with others. Gas fees are only charged if you decide to revoke the permit at a later time.'
+                  : 'Gas fees are charged when revoking a query permit.'
+              }`}
+              placement="bottom"
+            >
+              <InfoCircleOutlined
+                className="cursor-pointer hover:text-gray-500"
+                style={{ marginLeft: '1rem', fontSize: '25px' }}
+              />
+            </Tooltip>
           </h2>
           <p className="z-50 font-thin text-sm sm:text-base p-0">
             Please enter the name of the query permit you would like to{' '}
@@ -183,8 +204,8 @@ const PermissionPage = () => {
       </div>
       <div className="w-full text-center z-50 sm:px-20 lg:px-40 flex flex-col ">
         <form className="flex flex-col items-start mt-8  w-full">
-          <label className="text-left mb-1">query permit name or phrase</label>
-          {inputDataInput((e) => setinputData(e.target.value))}
+          <label className="text-left mb-1">Query permit name or phrase</label>
+          {inputDataInput((e) => setinputData(e.target.value.toUpperCase()))}
         </form>
         <div className="flex items-center mt-8">
           <Button

--- a/src/pages/provider/index.tsx
+++ b/src/pages/provider/index.tsx
@@ -104,7 +104,7 @@ const ProviderServicesPage = () => {
         ? requestDataInput(permitData.permitName, (e) =>
             setPermitData({
               ...permitData,
-              permitName: e.target.value,
+              permitName: e.target.value.toUpperCase(),
             })
           )
         : requestDataInput(viewingKey.key, (e) =>

--- a/src/pages/provider/request.tsx
+++ b/src/pages/provider/request.tsx
@@ -15,10 +15,11 @@ const ProviderRequestPage = () => {
   const requestDataInput = (onChange?: (e?: any) => void) => (
     <input
       onChange={onChange}
-      className=" focus-visible:outline-blue-600 focus-visible:outline-none  font-mono text-blue-600 bg-input-bg w-full py-3 px-3 rounded-md mb-4"
+      className=" focus-visible:outline-blue-600 focus-visible:outline-none font-mono text-blue-600 bg-input-bg w-full py-3 px-3 rounded-md mb-4"
       type={'text'}
     />
   );
+
   return (
     <div className="px-20 py-60 ">
       <div className="w-full text-center">
@@ -30,7 +31,7 @@ const ProviderRequestPage = () => {
           {requestDataInput((e) =>
             setRequestData({
               ...requestData,
-              permitName: e.target.value,
+              permitName: e.target.value.toUpperCase(),
             })
           )}
           <label className="text-left mb-1">Public Address</label>


### PR DESCRIPTION
 - [x] 1) The info icon doesn’t do anything, when the user clicks it they should see a tooltip (https://ant.design/components/tooltip/) letting them know they can only view this key once and that they should download it or save it and keep it safe. (There is no way a user can get a query permit info if they forget or lose it, to answer your question).

 

- [x] 2) Add an icon box with a tooltip on the create query page. The tooltip should tell the user that gas fees are not charged when create a query permit and that these permits can shared with others. Gas fees are only charged if they decide to revoke the permit at a later time.

 

- [x] 3) Always capitalize the permit name for both the user and the provider (when submitting to the blockchain).

 

- [x] 4) when creating a permit key and refreshing the page, every field is filled except the name field, please include the name field.

<img width="1440" alt="Screen Shot 2022-04-12 at 2 32 26 PM" src="https://user-images.githubusercontent.com/82831286/163060093-73b036fb-1fe8-4411-b4dc-478df6ef2c7b.png">
<img width="1440" alt="Screen Shot 2022-04-12 at 2 33 05 PM" src="https://user-images.githubusercontent.com/82831286/163060099-55268bb0-ce77-4447-aa0d-66e94f48acff.png">
<img width="1440" alt="Screen Shot 2022-04-12 at 2 31 47 PM" src="https://user-images.githubusercontent.com/82831286/163060102-5aaa7d19-d535-432d-a7a7-eaf7593655e7.png">
