### PR TITLE
store explanation in local storage

### DIFF
--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -42,12 +42,14 @@ export enum CHAIN_ACTIVITIES {
   dataProvider = 'dataProvider',
   scoreAmount = 'scoreAmount',
   viewingKey = 'viewingKey',
+  scoreMessage = 'scoreMessage',
 }
 export interface IChainActivity {
   [CHAIN_ACTIVITIES.scoreSubmitted]?: boolean;
   [CHAIN_ACTIVITIES.shareableLink]?: boolean;
   [CHAIN_ACTIVITIES.dataProvider]?: 'coinbase' | 'plaid';
   [CHAIN_ACTIVITIES.scoreAmount]?: number;
+  [CHAIN_ACTIVITIES.scoreMessage]?: string;
   [CHAIN_ACTIVITIES.viewingKey]?: string;
 }
 
@@ -57,6 +59,7 @@ export const CHAIN_ACTIVITY_INIT = {
   dataProvider: undefined,
   scoreAmount: undefined,
   viewingKey: undefined,
+  scoreMessage: undefined,
 };
 
 export interface PlaidToken {

--- a/src/pages/applicant/query.tsx
+++ b/src/pages/applicant/query.tsx
@@ -42,7 +42,7 @@ const QueryScorePage = () => {
 
   const getScore = async () => {
     setLoadingStatus();
-    if (!chainActivity?.scoreAmount) {
+    if (!chainActivity?.scoreAmount || !chainActivity?.scoreMessage) {
       const queryWithPermit: {
         response?: IPermitQueryResponse;
         status: 'error' | 'success' | string;

--- a/src/pages/applicant/score.tsx
+++ b/src/pages/applicant/score.tsx
@@ -74,6 +74,7 @@ const ApplicantScorePage = () => {
         setRecentlySaved(true);
         handleSetChainActivity({
           scoreAmount: scoreResponse?.score,
+          scoreMessage: scoreResponse?.message,
           scoreSubmitted: true,
           dataProvider: scoreResponse?.endpoint.includes('plaid')
             ? 'plaid'


### PR DESCRIPTION
when user queries score already in state, there was no explanation of score (wasn't be held in context) 


- added score message to context